### PR TITLE
fix: 공공데이터 api url 변경

### DIFF
--- a/오픈소스_데이터_분석_5강.ipynb
+++ b/오픈소스_데이터_분석_5강.ipynb
@@ -227,7 +227,7 @@
       "source": [
         "import requests\n",
         "\n",
-        "url = \"http://apis.data.go.kr/B552584/ArpltnInforInqireSvc/getMinuDustFrcstDspth\"\n",
+        "url = \"http://apis.data.go.kr/B552584/ArpltnInforInqireSvc/getCtprvnRltmMesureDnsty\"\n",
         "api_key = '[발급받은 인증키]'\n",
         "\n",
         "params = {\n",


### PR DESCRIPTION
## description
제공된 코드에 포함된 기존 URL로 조회 시 데이터가 강의 내용과 일치하지 않았습니다.
교재에 기재된 올바른 URL로 수정하여 강의와 동일한 결과가 나오도록 반영했습니다.

## screenshots
### 수정 전
<img width="605" height="531" alt="스크린샷 2025-09-18 17 04 47" src="https://github.com/user-attachments/assets/b8363bc8-f3fc-46d5-b162-ce4b2b5bdf69" />

### 수정 후
<img width="639" height="463" alt="스크린샷 2025-09-18 17 05 03" src="https://github.com/user-attachments/assets/37924cb4-07bd-47c5-a831-2b1e2e0c7087" />
